### PR TITLE
Ensure gen-item-documentation is referred into the parser module

### DIFF
--- a/src/parser.fnl
+++ b/src/parser.fnl
@@ -7,7 +7,7 @@ item in the module.  Supports sandboxing."
    [fennel :refer [dofile metadata]]
    [fennel.compiler]
    [cljlib :refer [get-in]]
-   [markdown :refer [gen-function-signature gen-item-signature]]))
+   [markdown :refer [gen-function-signature gen-item-signature gen-item-documentation]]))
 
 (defn- sandbox-module [module file]
   (setmetatable


### PR DESCRIPTION
I tried to look at opening a PR in GitLab but it's down 😅 feel free to close this here or just copy it into your local machine to do the commit. Just putting it here so it doesn't get lost / forgotten.